### PR TITLE
Add helper script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN mkdir /project
 
 WORKDIR /project
 
+ENV TRAVIS_CONFIG_PATH /travis
+
 COPY imagefiles/entrypoint.sh /usr/share/
 
 ENTRYPOINT ["/usr/share/entrypoint.sh", "travis"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apk add --no-cache build-base && \
 RUN apk add --no-cache git
 RUN mkdir project
 WORKDIR project
-VOLUME ["/project"]
 ENTRYPOINT ["travis"]
 
 # Build-time metadata as defined at http://label-schema.org

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ MAINTAINER caktux and Jean-Christophe Fillion-Robin "jchris.fillionr@kitware.com
 
 RUN apk add --no-cache build-base && \
     gem install travis && \
-    gem install travis-lint && \
     apk del build-base
 RUN apk add --no-cache git
 RUN mkdir project

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,18 @@ FROM ruby:alpine
 MAINTAINER caktux and Jean-Christophe Fillion-Robin "jchris.fillionr@kitware.com"
 
 RUN apk add --no-cache build-base && \
+    apk add --no-cache git && \
+    apk add --no-cache sudo && \
     gem install travis && \
     apk del build-base
-
-RUN apk add --no-cache git
 
 RUN mkdir /project
 
 WORKDIR /project
-ENTRYPOINT ["travis"]
+
+COPY imagefiles/entrypoint.sh /usr/share/
+
+ENTRYPOINT ["/usr/share/entrypoint.sh", "travis"]
 
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,12 @@ MAINTAINER caktux and Jean-Christophe Fillion-Robin "jchris.fillionr@kitware.com
 RUN apk add --no-cache build-base && \
     gem install travis && \
     apk del build-base
+
 RUN apk add --no-cache git
-RUN mkdir project
-WORKDIR project
+
+RUN mkdir /project
+
+WORKDIR /project
 ENTRYPOINT ["travis"]
 
 # Build-time metadata as defined at http://label-schema.org

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,16 @@ RUN mkdir project
 WORKDIR project
 VOLUME ["/project"]
 ENTRYPOINT ["travis"]
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.description="Dockerized version of Travis Command Line Client." \
+      org.label-schema.url="https://github.com/caktux/travis-cli" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ruby:alpine
-MAINTAINER caktux
+MAINTAINER caktux and Jean-Christophe Fillion-Robin "jchris.fillionr@kitware.com"
+
 RUN apk add --no-cache build-base && \
     gem install travis && \
     gem install travis-lint && \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+#
+# Parameters
+#
+
+# Name of the docker executable
+DOCKER = docker
+
+# Docker organization to pull the images from
+ORG = caktux
+
+# Name of image
+IMAGE = travis-cli
+
+build:
+	docker build -t $(ORG)/$(IMAGE) .
+
+push:
+	docker push $(ORG)/$(IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,12 @@ ORG = caktux
 IMAGE = travis-cli
 
 build:
-	docker build -t $(ORG)/$(IMAGE) .
+	docker build \
+		--build-arg IMAGE=$(IMAGE) \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` \
+		--build-arg VCS_URL=`git config --get remote.origin.url` \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		-t $(ORG)/$(IMAGE) .
 
 push:
 	docker push $(ORG)/$(IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 DOCKER = docker
 
 # Docker organization to pull the images from
-ORG = caktux
+ORG = jcfr
 
 # Name of image
 IMAGE = travis-cli

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Dockerized version of [Travis Command Line Client](https://github.com/travis-ci/travis.rb)
 
-[![](https://images.microbadger.com/badges/version/caktux/travis-cli.svg)](https://microbadger.com/images/caktux/travis-cli "Get your own version badge on microbadger.com")
+[![](https://images.microbadger.com/badges/version/jcfr/travis-cli.svg)](https://microbadger.com/images/jcfr/travis-cli "Get your own version badge on microbadger.com")
 
 ## Installation
 
@@ -12,7 +12,7 @@ to execute it.
 To install the helper script, copy the script `travis-cli` in your `PATH`:
 
 ```shell
-curl https://raw.githubusercontent.com/caktux/travis-cli/master/travis-cli.sh \
+curl https://raw.githubusercontent.com/jcfr/docker-travis-cli/master/travis-cli.sh \
   -o ~/bin/travis-cli && \
 chmod +x ~/bin/travis-cli
 ```
@@ -87,7 +87,7 @@ run `/usr/local/bundle/bin/travis help COMMAND` for more infos
 To rebuild the image:
 
 ```shell
-git clone git://github.com/caktux/travis-cli
+git clone git://github.com/jcfr/docker-travis-cli
 make build
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Dockerized version of [Travis Command Line Client](https://github.com/travis-ci/travis.rb)
 
+[![](https://images.microbadger.com/badges/version/caktux/travis-cli.svg)](https://microbadger.com/images/caktux/travis-cli "Get your own version badge on microbadger.com")
+
 ## Installation
 
 This image does not need to be run manually. Instead, there is a helper script

--- a/README.md
+++ b/README.md
@@ -1,26 +1,83 @@
 # docker-travis-cli
 
-Travis CLI in a `ruby:alpine` image.
+Dockerized version of [Travis Command Line Client](https://github.com/travis-ci/travis.rb)
 
-## Pull and tag
+## Installation
+
+This image does not need to be run manually. Instead, there is a helper script
+to execute it.
+
+To install the helper script, copy the script `travis-cli` in your `PATH`:
+
 ```shell
-docker pull caktux/travis-cli
-docker tag caktux/travis-cli travis-cli
+curl https://raw.githubusercontent.com/caktux/travis-cli/master/travis-cli.sh \
+  -o ~/bin/travis-cli && \
+chmod +x ~/bin/travis-cli
 ```
 
-## Encrypting environment variables
+## Examples
+
+### Encrypting environment variables
 ```shell
-docker run --rm travis-cli encrypt SECRET=123 -r org/repo
+travis-cli encrypt SECRET=123 -r org/repo
 ```
 
-## Interactive setup of `.travis.yml`
-```
-docker run --rm -it -v ~/project:/project travis-cli setup pypi
-```
-
-## Validating your `.travis.yml`
+### Interactive setup of `.travis.yml`
 ```shell
-docker run --rm -v ~/project:/project travis-cli lint /project/.travis.yml
+travis-cli setup pypi
+```
+
+### Validating your `.travis.yml` with travis lint
+```shell
+travis-cli lint .travis.yml
+```
+
+## Usage
+
+```shell
+$ travis-cli help
+Usage: travis COMMAND ...
+
+Available commands:
+
+	accounts       displays accounts and their subscription status
+	branches       displays the most recent build for each branch
+	cache          lists or deletes repository caches
+	cancel         cancels a job or build
+	console        interactive shell
+	disable        disables a project
+	enable         enables a project
+	encrypt        encrypts values for the .travis.yml
+	encrypt-file   encrypts a file and adds decryption steps to .travis.yml
+	endpoint       displays or changes the API endpoint
+	env            show or modify build environment variables
+	help           helps you out when in dire need of information
+	history        displays a projects build history
+	init           generates a .travis.yml and enables the project
+	lint           display warnings for a .travis.yml
+	login          authenticates against the API and stores the token
+	logout         deletes the stored API token
+	logs           streams test logs
+	monitor        live monitor for what's going on
+	open           opens a build or job in the browser
+	pubkey         prints out a repository's public key
+	raw            makes an (authenticated) API call and prints out the result
+	report         generates a report useful for filing issues
+	repos          lists repositories the user has certain permissions on
+	requests       lists recent requests
+	restart        restarts a build or job
+	settings       access repository settings
+	setup          sets up an addon or deploy target
+	show           displays a build or job
+	sshkey         checks, updates or deletes an SSH key
+	status         checks status of the latest build
+	sync           triggers a new sync with GitHub
+	token          outputs the secret API token
+	version        outputs the client version
+	whatsup        lists most recent builds
+	whoami         outputs the current user
+
+run `/usr/local/bundle/bin/travis help COMMAND` for more infos
 ```
 
 ## Maintenance
@@ -32,9 +89,14 @@ git clone git://github.com/caktux/travis-cli
 make build
 ```
 
-To publish the image::
+To publish the image:
 
 ```shell
 docker login -u <user> -p <password>
 make push
 ```
+
+---
+
+Credits go to [sdt/docker-raspberry-pi-cross-compiler](https://github.com/sdt/docker-raspberry-pi-cross-compiler), who invented the base of the dockerized script.
+

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ docker run --rm travis-cli encrypt SECRET=123 -r org/repo
 docker run --rm -it -v ~/project:/project travis-cli setup pypi
 ```
 
-## Validating your `.travis.yml` with travis-lint
+## Validating your `.travis.yml`
 ```shell
-docker run --rm -v ~/project:/project --entrypoint=travis-lint travis-cli /project/.travis.yml
+docker run --rm -v ~/project:/project travis-cli lint /project/.travis.yml
 ```
 
 ## Maintenance

--- a/README.md
+++ b/README.md
@@ -22,3 +22,19 @@ docker run --rm -it -v ~/project:/project travis-cli setup pypi
 ```shell
 docker run --rm -v ~/project:/project --entrypoint=travis-lint travis-cli /project/.travis.yml
 ```
+
+## Maintenance
+
+To rebuild the image:
+
+```shell
+git clone git://github.com/caktux/travis-cli
+make build
+```
+
+To publish the image::
+
+```shell
+docker login -u <user> -p <password>
+make push
+```

--- a/imagefiles/entrypoint.sh
+++ b/imagefiles/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# This is the entrypoint script for the dockerfile. Executed in the
+# container at runtime.
+
+# If we are running docker natively, we want to create a user in the container
+# with the same UID and GID as the user on the host machine, so that any files
+# created are owned by that user. Without this they are all owned by root.
+# If we are running from boot2docker, this is not necessary.
+# The dockcross script sets the BUILDER_UID and BUILDER_GID vars.
+
+if [[ -n $BUILDER_UID ]] && [[ -n $BUILDER_GID ]]; then
+
+  addgroup -g $BUILDER_GID $BUILDER_GROUP
+  adduser -u $BUILDER_UID -D -H -G $BUILDER_GROUP $BUILDER_USER
+
+  cp -r /root /home/$BUILDER_USER
+  chown -R $BUILDER_USER:$BUILDER_GROUP  /home/$BUILDER_USER
+
+  export HOME=/home/${BUILDER_USER}
+
+  # Run the command as the specified user/group.
+  exec sudo -E -u $BUILDER_USER "$@"
+
+else
+    # Just run the command as root.
+    exec "$@"
+fi

--- a/imagefiles/entrypoint.sh
+++ b/imagefiles/entrypoint.sh
@@ -17,6 +17,8 @@ if [[ -n $BUILDER_UID ]] && [[ -n $BUILDER_GID ]]; then
   cp -r /root /home/$BUILDER_USER
   chown -R $BUILDER_USER:$BUILDER_GROUP  /home/$BUILDER_USER
 
+  chown -R $BUILDER_USER:$BUILDER_GROUP  /travis
+
   export HOME=/home/${BUILDER_USER}
 
   # Run the command as the specified user/group.

--- a/travis-cli.sh
+++ b/travis-cli.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+FINAL_IMAGE=caktux/travis-cli
+
+#
+# If we are not running via boot2docker
+#
+if [ -z $DOCKER_HOST ]; then
+    USER_IDS="-e BUILDER_UID=$( id -u ) -e BUILDER_GID=$( id -g ) -e BUILDER_USER=$( id -un ) -e BUILDER_GROUP=$( id -gn )"
+fi
+
+#
+# Run the command in a container
+#
+tty -s && TTY_ARGS=-ti || TTY_ARGS=
+docker run $TTY_ARGS --rm \
+    -v $PWD:/project \
+    $USER_IDS \
+    $FINAL_IMAGE "$@"
+

--- a/travis-cli.sh
+++ b/travis-cli.sh
@@ -14,6 +14,7 @@ fi
 #
 tty -s && TTY_ARGS=-ti || TTY_ARGS=
 docker run $TTY_ARGS --rm \
+    -v ~/.travis:/travis \
     -v $PWD:/project \
     $USER_IDS \
     $FINAL_IMAGE "$@"

--- a/travis-cli.sh
+++ b/travis-cli.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-FINAL_IMAGE=caktux/travis-cli
+FINAL_IMAGE=jcfr/travis-cli
 
 #
 # If we are not running via boot2docker


### PR DESCRIPTION
 Add helper script allowing to automatically mount current folder

Instead of running the image using:

```
  $ docker run --rm travis-cli encrypt SECRET=123 -r org/repo
```

The following can be done:

```
  $ /path/to/travis-cli.sh encrypt SECRET=123 -r org/repo
```
